### PR TITLE
ImageButter-imageViewBlockSet

### DIFF
--- a/WebPImageView.h
+++ b/WebPImageView.h
@@ -24,6 +24,11 @@ fetch the image from disk or remotely.
 @property(nonatomic)NSURL *url;
 
 /**
+ expose the progress and finished blocks for image setting from URL
+ */
+- (void)setUrl:(NSURL*)url progress:(WebPImageProgress)progress finished:(WebPImageFinished)finished;
+
+/**
  Show a loading view will the image gets fetched.
  */
 @property(nonatomic)UIView<WebPImageViewProgressDelegate> *loadingView;


### PR DESCRIPTION
- expose the progress and completion block for image setting.
- refactor `setURL:` to use the block based method internally
